### PR TITLE
fix: downgrade version to retrigger publish

### DIFF
--- a/packages/site/CHANGELOG.md
+++ b/packages/site/CHANGELOG.md
@@ -5,15 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
-## [0.2.0]
-### Changes
 - Fix chain config for the companion dapp ([#8](https://github.com/MetaMask/snap-account-abstraction-keyring/pull/8))
 
 ## [0.1.0] - 2024-01-15
 ### Added
 - Initial release.
 
-[Unreleased]: https://github.com/MetaMask/snap-account-abstraction-keyring/compare/v0.2.0...HEAD
-[0.2.0]: https://github.com/MetaMask/snap-account-abstraction-keyring/compare/v0.1.0...v0.2.0
+[Unreleased]: https://github.com/MetaMask/snap-account-abstraction-keyring/compare/v0.1.0...HEAD
 [0.1.0]: https://github.com/MetaMask/snap-account-abstraction-keyring/releases/tag/v0.1.0

--- a/packages/site/package.json
+++ b/packages/site/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@metamask/snap-account-abstraction-keyring-site",
-  "version": "0.2.0",
-  "private": true,
+  "version": "0.1.0",
   "license": "(MIT-0 OR Apache-2.0)",
   "scripts": {
     "allow-scripts": "yarn workspace @metamask/snap-account-abstraction-keyring allow-scripts",

--- a/packages/snap/CHANGELOG.md
+++ b/packages/snap/CHANGELOG.md
@@ -5,14 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
-## [0.2.0]
-### Added
 - Add userop methods and updates account creation ([#4](https://github.com/MetaMask/snap-account-abstraction-keyring/pull/4))
 - Add contract addresses and deployment script ([#2](https://github.com/MetaMask/snap-account-abstraction-keyring/pull/2))
-
-
-### Changes
 - Fix regex to support query parameters ([#13](https://github.com/MetaMask/snap-account-abstraction-keyring/pull/13))
 - Fix initcode generation ([#8](https://github.com/MetaMask/snap-account-abstraction-keyring/pull/8))
 
@@ -20,6 +14,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial release.
 
-[Unreleased]: https://github.com/MetaMask/snap-account-abstraction-keyring/compare/v0.2.0...HEAD
-[0.2.0]: https://github.com/MetaMask/snap-account-abstraction-keyring/compare/v0.1.0...v0.2.0
+[Unreleased]: https://github.com/MetaMask/snap-account-abstraction-keyring/compare/v0.1.0...HEAD
 [0.1.0]: https://github.com/MetaMask/snap-account-abstraction-keyring/releases/tag/v0.1.0

--- a/packages/snap/package.json
+++ b/packages/snap/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@metamask/snap-account-abstraction-keyring-snap",
-  "version": "0.2.0",
-  "private": true,
+  "version": "0.1.0",
   "description": "An account abstraction keyring snap that integrates with MetaMask accounts.",
   "keywords": [
     "metamask",

--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.2.0",
+  "version": "0.1.0",
   "description": "An account abstraction keyring snap that integrates with MetaMask accounts.",
   "proposedName": "MetaMask Account Abstraction Snap Keyring",
   "repository": {
@@ -7,7 +7,7 @@
     "url": "git+https://github.com/MetaMask/snap-account-abstraction-keyring.git"
   },
   "source": {
-    "shasum": "QOzYl3G/Hu71ra4BuYhx+nwHBPNXk0JH/ag15Ukd1vU=",
+    "shasum": "ovra153sNkMAeoTOn3UcW1jrXsM+EUVfHMbL+R5wx90=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",


### PR DESCRIPTION
This pr removes the 0.2.0 changes to republish the version