### PR TITLE
Feat: remove pending requests and associated methods

### DIFF
--- a/packages/site/src/pages/index.tsx
+++ b/packages/site/src/pages/index.tsx
@@ -16,7 +16,7 @@ import { defaultSnapOrigin } from '../config';
 import { MetamaskActions, MetaMaskContext } from '../hooks';
 import { InputType } from '../types';
 import type { KeyringState } from '../utils';
-import { connectSnap, getSnap, isSynchronousMode } from '../utils';
+import { connectSnap, getSnap } from '../utils';
 
 const snapId = defaultSnapOrigin;
 
@@ -58,11 +58,8 @@ const Index = () => {
       }
       const accounts = await client.listAccounts();
       const pendingRequests = await client.listRequests();
-      const isSynchronous = await isSynchronousMode();
       setSnapState({
         accounts,
-        pendingRequests,
-        useSynchronousApprovals: isSynchronous,
       });
     }
 
@@ -100,7 +97,6 @@ const Index = () => {
     await syncAccounts();
   };
 
-  // UserOp methods (default to send from first AA account created)
   const setChainConfig = async () => {
     if (!chainConfig) {
       return;
@@ -131,16 +127,6 @@ const Index = () => {
       dispatch({ type: MetamaskActions.SetError, payload: error });
     }
   };
-
-  // Note: not using this for now
-  // const handleUseSyncToggle = useCallback(async () => {
-  //   console.log('Toggling synchronous approval');
-  //   await toggleSynchronousApprovals();
-  //   setSnapState({
-  //     ...snapState,
-  //     useSynchronousApprovals: !snapState.useSynchronousApprovals,
-  //   });
-  // }, [snapState]);
 
   const userOpMethods = [
     {
@@ -283,85 +269,6 @@ const Index = () => {
     },
   ];
 
-  const requestMethods = [
-    {
-      name: 'Get request',
-      description: 'Get a pending request by ID',
-      inputs: [
-        {
-          id: 'get-request-request-id',
-          title: 'Request ID',
-          type: InputType.TextField,
-          placeholder: 'E.g. e5156958-16ad-4d5d-9dcd-6a8ba1d34906',
-          onChange: (event: any) => setRequestId(event.currentTarget.value),
-        },
-      ],
-      action: {
-        enabled: Boolean(requestId),
-        callback: async () => await client.getRequest(requestId as string),
-        label: 'Get Request',
-      },
-    },
-    {
-      name: 'List requests',
-      description: 'List pending requests',
-      action: {
-        disabled: false,
-        callback: async () => {
-          const requests = await client.listRequests();
-          setSnapState({
-            ...snapState,
-            pendingRequests: requests,
-          });
-          return requests;
-        },
-        label: 'List Requests',
-      },
-    },
-    {
-      name: 'Approve request',
-      description: 'Approve a pending request by ID',
-      inputs: [
-        {
-          id: 'approve-request-request-id',
-          title: 'Request ID',
-          type: InputType.TextField,
-          placeholder: 'E.g. 6fcbe1b5-f250-452c-8114-683dfa5ea74d',
-          onChange: (event: any) => {
-            setRequestId(event.currentTarget.value);
-          },
-        },
-      ],
-      action: {
-        disabled: !requestId,
-        callback: async () => await client.approveRequest(requestId as string),
-        label: 'Approve Request',
-      },
-      successMessage: 'Request approved',
-    },
-    {
-      name: 'Reject request',
-      description: 'Reject a pending request by ID',
-      inputs: [
-        {
-          id: 'reject-request-request-id',
-          title: 'Request ID',
-          type: InputType.TextField,
-          placeholder: 'E.g. 424ad2ee-56cf-493e-af82-cee79c591117',
-          onChange: (event: any) => {
-            setRequestId(event.currentTarget.value);
-          },
-        },
-      ],
-      action: {
-        disabled: !requestId,
-        callback: async () => await client.rejectRequest(requestId as string),
-        label: 'Reject Request',
-      },
-      successMessage: 'Request Rejected',
-    },
-  ];
-
   return (
     <Container>
       <CardContainer>
@@ -386,23 +293,11 @@ const Index = () => {
       <StyledBox sx={{ flexGrow: 1 }}>
         <Grid container spacing={4} columns={[1, 2, 3]}>
           <Grid item xs={8} sm={4} md={2}>
-            {/* Not using this for now*/}
-            {/* <DividerTitle>Options</DividerTitle>*/}
-            {/* <Toggle*/}
-            {/*  title="Use Synchronous Approval"*/}
-            {/*  defaultChecked={snapState.useSynchronousApprovals}*/}
-            {/*  onToggle={handleUseSyncToggle}*/}
-            {/*  enabled={Boolean(state.installedSnap)}*/}
-            {/*/ >*/}
-            {/* <Divider>&nbsp;</Divider>*/}
             <DividerTitle>Methods</DividerTitle>
             <Accordion items={accountManagementMethods} />
             <Divider />
             <DividerTitle>UserOp Methods</DividerTitle>
             <Accordion items={userOpMethods} />
-            <Divider />
-            <DividerTitle>Request Methods</DividerTitle>
-            <Accordion items={requestMethods} />
             <Divider />
           </Grid>
           <Grid item xs={4} sm={2} md={1}>

--- a/packages/site/src/pages/index.tsx
+++ b/packages/site/src/pages/index.tsx
@@ -40,7 +40,6 @@ const Index = () => {
   const [salt, setSalt] = useState<string | null>();
   const [accountId, setAccountId] = useState<string | null>();
   const [accountObject, setAccountObject] = useState<string | null>();
-  const [requestId, setRequestId] = useState<string | null>(null);
   // UserOp method state
   const [chainConfig, setChainConfigObject] = useState<string | null>();
 
@@ -57,7 +56,6 @@ const Index = () => {
         return;
       }
       const accounts = await client.listAccounts();
-      const pendingRequests = await client.listRequests();
       setSnapState({
         accounts,
       });

--- a/packages/site/src/utils/keyring-snap.ts
+++ b/packages/site/src/utils/keyring-snap.ts
@@ -1,9 +1,7 @@
-import type { KeyringAccount, KeyringRequest } from '@metamask/keyring-api';
+import type { KeyringAccount } from '@metamask/keyring-api';
 
 export type KeyringState = {
-  pendingRequests: KeyringRequest[];
   accounts: KeyringAccount[];
-  useSynchronousApprovals: boolean;
 };
 
 /**

--- a/packages/site/src/utils/snap.ts
+++ b/packages/site/src/utils/snap.ts
@@ -67,30 +67,4 @@ export const sendHello = async () => {
   });
 };
 
-/**
- * Toggle synchronous approvals.
- */
-
-export const toggleSynchronousApprovals = async () => {
-  await window.ethereum.request({
-    method: 'wallet_invokeSnap',
-    params: {
-      snapId: defaultSnapOrigin,
-      request: { method: 'snap.internal.toggleSynchronousApprovals' },
-    },
-  });
-};
-
-// Note: not used in the example
-export const isSynchronousMode = async (): Promise<boolean> => {
-  // return (await window.ethereum.request({
-  //   method: 'wallet_invokeSnap',
-  //   params: {
-  //     snapId: defaultSnapOrigin,
-  //     request: { method: 'snap.internal.isSynchronousMode' },
-  //   },
-  // })) as boolean;
-  return true;
-};
-
 export const isLocalSnap = (snapId: string) => snapId.startsWith('local:');

--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "git+https://github.com/MetaMask/snap-account-abstraction-keyring.git"
   },
   "source": {
-    "shasum": "OBn6ARKAyt0CI8IUiJJEW/BYS5WLdlsMvjJZiPMzCzY=",
+    "shasum": "WfB+J7Rzl/po7NKMCmFe9KLNUfps/dncIaWtCm/WvWQ=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",
@@ -21,8 +21,7 @@
     "endowment:keyring": {
       "allowedOrigins": [
         "https://metamask.github.io",
-        "http://localhost:8000",
-        "http://localhost:8080"
+        "http://localhost:8000"
       ]
     },
     "endowment:rpc": {

--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "git+https://github.com/MetaMask/snap-account-abstraction-keyring.git"
   },
   "source": {
-    "shasum": "5Jila6+Ekh3meLDdJZBMKjM6Lto1P+qVUL/oKt+MZ1U=",
+    "shasum": "OBn6ARKAyt0CI8IUiJJEW/BYS5WLdlsMvjJZiPMzCzY=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snap/src/keyring.test.ts
+++ b/packages/snap/src/keyring.test.ts
@@ -55,7 +55,6 @@ global.snap = {
 
 const defaultState: KeyringState = {
   wallets: {},
-  pendingRequests: {},
   config: {},
 };
 
@@ -98,7 +97,6 @@ describe('Keyring', () => {
     it('should create a new keyring with default state', async () => {
       expect(keyring).toBeDefined();
       expect(await keyring.listAccounts()).toStrictEqual([]);
-      expect(await keyring.listRequests()).toStrictEqual([]);
     });
   });
 

--- a/packages/snap/src/keyring.ts
+++ b/packages/snap/src/keyring.ts
@@ -74,7 +74,6 @@ export type ChainConfig = {
 
 export type KeyringState = {
   wallets: Record<string, Wallet>;
-  pendingRequests: Record<string, KeyringRequest>;
   config: Record<number, ChainConfig>;
 };
 
@@ -295,27 +294,6 @@ export class AccountAbstractionKeyring implements Keyring {
   }
 
   /**
-   * List all pending requests.
-   *
-   * @returns A list of pending requests.
-   */
-  async listRequests(): Promise<KeyringRequest[]> {
-    return Object.values(this.#state.pendingRequests);
-  }
-
-  /**
-   * Get a pending request by its ID.
-   *
-   * @param id - The ID of the request to retrieve.
-   * @returns The pending request with the given ID.
-   */
-  async getRequest(id: string): Promise<KeyringRequest> {
-    return (
-      this.#state.pendingRequests[id] ?? throwError(`Request '${id}' not found`)
-    );
-  }
-
-  /**
    * Submit a request to the keyring.
    *
    * @param request - The keyring request to submit.
@@ -323,47 +301,6 @@ export class AccountAbstractionKeyring implements Keyring {
    */
   async submitRequest(request: KeyringRequest): Promise<SubmitRequestResponse> {
     return this.#syncSubmitRequest(request);
-  }
-
-  /**
-   * Approve a pending request.
-   *
-   * @param id - The ID of the keyring request to approve.
-   * @throws If the request is not found.
-   */
-  async approveRequest(id: string): Promise<void> {
-    const { account, request } =
-      this.#state.pendingRequests[id] ??
-      throwError(`Request '${id}' not found`);
-
-    const result = await this.#handleSigningRequest({
-      account: this.#getWalletById(account).account,
-      method: request.method,
-      params: request.params ?? [],
-    });
-
-    await this.#removePendingRequest(id);
-    await this.#emitEvent(KeyringEvent.RequestApproved, { id, result });
-  }
-
-  /**
-   * Reject a pending request.
-   *
-   * @param id - The ID of the keyring request to reject.
-   * @throws If the request is not found.
-   */
-  async rejectRequest(id: string): Promise<void> {
-    if (this.#state.pendingRequests[id] === undefined) {
-      throw new Error(`Request '${id}' not found`);
-    }
-
-    await this.#removePendingRequest(id);
-    await this.#emitEvent(KeyringEvent.RequestRejected, { id });
-  }
-
-  async #removePendingRequest(id: string): Promise<void> {
-    delete this.#state.pendingRequests[id];
-    await this.#saveState();
   }
 
   async #syncSubmitRequest(

--- a/packages/snap/src/keyring.ts
+++ b/packages/snap/src/keyring.ts
@@ -73,7 +73,6 @@ export type ChainConfig = {
 
 export type KeyringState = {
   wallets: Record<string, Wallet>;
-  pendingRequests: Record<string, KeyringRequest>;
   config: Record<number, ChainConfig>;
 };
 
@@ -287,47 +286,8 @@ export class AccountAbstractionKeyring implements Keyring {
     }
   }
 
-  async listRequests(): Promise<KeyringRequest[]> {
-    return Object.values(this.#state.pendingRequests);
-  }
-
-  async getRequest(id: string): Promise<KeyringRequest> {
-    return (
-      this.#state.pendingRequests[id] ?? throwError(`Request '${id}' not found`)
-    );
-  }
-
   async submitRequest(request: KeyringRequest): Promise<SubmitRequestResponse> {
     return this.#syncSubmitRequest(request);
-  }
-
-  async approveRequest(id: string): Promise<void> {
-    const { account, request } =
-      this.#state.pendingRequests[id] ??
-      throwError(`Request '${id}' not found`);
-
-    const result = await this.#handleSigningRequest({
-      account: this.#getWalletById(account).account,
-      method: request.method,
-      params: request.params ?? [],
-    });
-
-    await this.#removePendingRequest(id);
-    await this.#emitEvent(KeyringEvent.RequestApproved, { id, result });
-  }
-
-  async rejectRequest(id: string): Promise<void> {
-    if (this.#state.pendingRequests[id] === undefined) {
-      throw new Error(`Request '${id}' not found`);
-    }
-
-    await this.#removePendingRequest(id);
-    await this.#emitEvent(KeyringEvent.RequestRejected, { id });
-  }
-
-  async #removePendingRequest(id: string): Promise<void> {
-    delete this.#state.pendingRequests[id];
-    await this.#saveState();
   }
 
   async #syncSubmitRequest(

--- a/packages/snap/src/stateManagement.ts
+++ b/packages/snap/src/stateManagement.ts
@@ -6,7 +6,6 @@ import { logger } from './logger';
  */
 const defaultState: KeyringState = {
   wallets: {},
-  pendingRequests: {},
   config: {},
 };
 


### PR DESCRIPTION
## Description

No need to keep [pendingRequests](https://github.com/MetaMask/snap-account-abstraction-keyring/blob/main/packages/snap/src/keyring.ts#L76) in the KeyringState. Since we are not using the async flow, we will never have any requests pending. 

Since we will not have an async flow and pending requests, the following optional keyring methods can be removed:

- listRequests
- getRequest
- approveRequest
- rejectRequest

Additionally we can remove the asynchronous request methods and toggle for synchronous versus asynchronous approval from the front end.

Note: Clean up task by removing `"http://localhost:8080"` from `allowedOrigins`