### PR TITLE
test: refactor chain configuration unit test

### DIFF
--- a/packages/snap/src/keyring.test.ts
+++ b/packages/snap/src/keyring.test.ts
@@ -116,61 +116,46 @@ describe('Keyring', () => {
       };
     });
 
-    it('should not set the config with an invalid simpleAccountFactory address', async () => {
-      const invalidConfig: ChainConfig = {
-        ...config,
-        simpleAccountFactory: '0xNotAnAddress',
-      };
-      await expect(keyring.setConfig(invalidConfig)).rejects.toThrow(
-        `[Snap] Invalid Simple Account Factory Address: ${
-          invalidConfig.simpleAccountFactory as string
-        }`,
-      );
+    const testCases = [
+      {
+        field: 'simpleAccountFactory',
+        value: '0xNotAnAddress',
+        errorMessage: 'Invalid Simple Account Factory Address',
+      },
+      {
+        field: 'entryPoint',
+        value: '0xNotAnAddress',
+        errorMessage: 'Invalid Entry Point Address',
+      },
+      {
+        field: 'customVerifyingPaymasterAddress',
+        value: '0xNotAnAddress',
+        errorMessage: 'Invalid Custom Verifying Paymaster Address',
+      },
+      {
+        field: 'bundlerUrl',
+        value: 'https:/invalid.fake.io',
+        errorMessage: 'Invalid Bundler URL',
+      },
+      {
+        field: 'customVerifyingPaymasterPK',
+        value: '123NotAPrivateKey456',
+        errorMessage: 'Invalid Custom Verifying Paymaster Private Key',
+      },
+    ];
+
+    testCases.forEach(({ field, value, errorMessage }) => {
+      it(`should not set the config with an invalid ${field}`, async () => {
+        const invalidConfig = { ...config, [field]: value };
+        await expect(keyring.setConfig(invalidConfig)).rejects.toThrow(
+          `[Snap] ${errorMessage}: ${value}`,
+        );
+      });
     });
-    it('should not set the config with an invalid entryPoint address', async () => {
-      const invalidConfig: ChainConfig = {
-        ...config,
-        entryPoint: '0xNotAnAddress',
-      };
-      await expect(keyring.setConfig(invalidConfig)).rejects.toThrow(
-        `[Snap] Invalid Entry Point Address: ${
-          invalidConfig.entryPoint as string
-        }`,
-      );
-    });
-    it('should not set the config with an invalid customVerifyingPaymasterAddress', async () => {
-      const invalidConfig: ChainConfig = {
-        ...config,
-        customVerifyingPaymasterAddress: '0xNotAnAddress',
-      };
-      await expect(keyring.setConfig(invalidConfig)).rejects.toThrow(
-        `[Snap] Invalid Custom Verifying Paymaster Address: ${
-          invalidConfig.customVerifyingPaymasterAddress as string
-        }`,
-      );
-    });
-    it('should not set the config with an invalid bundlerUrl', async () => {
-      const invalidConfig: ChainConfig = {
-        ...config,
-        bundlerUrl: 'https:/invalid.fake.io',
-      };
-      await expect(keyring.setConfig(invalidConfig)).rejects.toThrow(
-        `[Snap] Invalid Bundler URL: ${invalidConfig.bundlerUrl as string}`,
-      );
-    });
-    it('should not set the config with an invalid customVerifyingPaymasterPK', async () => {
-      const invalidConfig: ChainConfig = {
-        ...config,
-        customVerifyingPaymasterPK: '123NotAPrivateKey456',
-      };
-      await expect(keyring.setConfig(invalidConfig)).rejects.toThrow(
-        `[Snap] Invalid Custom Verifying Paymaster Private Key`,
-      );
-    });
+
     it('should set the config', async () => {
       const keyringConfig = await keyring.setConfig(config);
       expect(keyringConfig).toStrictEqual(config);
-    });
   });
 
   describe('Create Account', () => {

--- a/packages/snap/src/keyring.test.ts
+++ b/packages/snap/src/keyring.test.ts
@@ -116,43 +116,37 @@ describe('Keyring', () => {
       };
     });
 
-    const testCases = [
-      {
-        field: 'simpleAccountFactory',
-        value: '0xNotAnAddress',
-        errorMessage: 'Invalid Simple Account Factory Address',
-      },
-      {
-        field: 'entryPoint',
-        value: '0xNotAnAddress',
-        errorMessage: 'Invalid Entry Point Address',
-      },
-      {
-        field: 'customVerifyingPaymasterAddress',
-        value: '0xNotAnAddress',
-        errorMessage: 'Invalid Custom Verifying Paymaster Address',
-      },
-      {
-        field: 'bundlerUrl',
-        value: 'https:/invalid.fake.io',
-        errorMessage: 'Invalid Bundler URL',
-      },
-      {
-        field: 'customVerifyingPaymasterPK',
-        value: '123NotAPrivateKey456',
-        errorMessage: 'Invalid Custom Verifying Paymaster Private Key',
-      },
-    ];
+describe('Set Config', () => {
+  let config: ChainConfig;
 
-    testCases.forEach(({ field, value, errorMessage }) => {
-      it(`should not set the config with an invalid ${field}`, async () => {
-        const invalidConfig = { ...config, [field]: value };
-        await expect(keyring.setConfig(invalidConfig)).rejects.toThrow(
-          `[Snap] ${errorMessage}: ${value}`,
-        );
-      });
-    });
+  beforeEach(async () => {
+    config = {
+      simpleAccountFactory: '0x9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0',
+      entryPoint: '0x5FbDB2315678afecb367f032d93F642f64180aa3',
+      bundlerUrl: 'https://bundler.example.com/rpc',
+      customVerifyingPaymasterPK: aaOwnerPk,
+      customVerifyingPaymasterAddress: '0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512',
+    };
+  });
 
+  const testCases = [
+    ['simpleAccountFactory', '0xNotAnAddress', 'Invalid Simple Account Factory Address'],
+    ['entryPoint', '0xNotAnAddress', 'Invalid Entry Point Address'],
+    ['customVerifyingPaymasterAddress', '0xNotAnAddress', 'Invalid Custom Verifying Paymaster Address'],
+    ['bundlerUrl', 'https:/invalid.fake.io', 'Invalid Bundler URL'],
+    ['customVerifyingPaymasterPK', '123NotAPrivateKey456', 'Invalid Custom Verifying Paymaster Private Key'],
+  ];
+
+  it.each(testCases)('should not set the config with an invalid %s', async (field, value, errorMessage) => {
+    const invalidConfig = { ...config, [field]: value };
+    await expect(keyring.setConfig(invalidConfig)).rejects.toThrow(`[Snap] ${errorMessage}: ${value}`);
+  });
+
+  it('should set the config', async () => {
+    const keyringConfig = await keyring.setConfig(config);
+    expect(keyringConfig).toStrictEqual(config);
+  });
+});
     it('should set the config', async () => {
       const keyringConfig = await keyring.setConfig(config);
       expect(keyringConfig).toStrictEqual(config);

--- a/packages/snap/src/keyring.test.ts
+++ b/packages/snap/src/keyring.test.ts
@@ -156,6 +156,7 @@ describe('Keyring', () => {
     it('should set the config', async () => {
       const keyringConfig = await keyring.setConfig(config);
       expect(keyringConfig).toStrictEqual(config);
+    });
   });
 
   describe('Create Account', () => {

--- a/packages/snap/src/keyring.test.ts
+++ b/packages/snap/src/keyring.test.ts
@@ -116,37 +116,43 @@ describe('Keyring', () => {
       };
     });
 
-describe('Set Config', () => {
-  let config: ChainConfig;
+    const testCases = [
+      {
+        field: 'simpleAccountFactory',
+        value: '0xNotAnAddress',
+        errorMessage: 'Invalid Simple Account Factory Address',
+      },
+      {
+        field: 'entryPoint',
+        value: '0xNotAnAddress',
+        errorMessage: 'Invalid Entry Point Address',
+      },
+      {
+        field: 'customVerifyingPaymasterAddress',
+        value: '0xNotAnAddress',
+        errorMessage: 'Invalid Custom Verifying Paymaster Address',
+      },
+      {
+        field: 'bundlerUrl',
+        value: 'https:/invalid.fake.io',
+        errorMessage: 'Invalid Bundler URL',
+      },
+      {
+        field: 'customVerifyingPaymasterPK',
+        value: '123NotAPrivateKey456',
+        errorMessage: 'Invalid Custom Verifying Paymaster Private Key',
+      },
+    ];
 
-  beforeEach(async () => {
-    config = {
-      simpleAccountFactory: '0x9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0',
-      entryPoint: '0x5FbDB2315678afecb367f032d93F642f64180aa3',
-      bundlerUrl: 'https://bundler.example.com/rpc',
-      customVerifyingPaymasterPK: aaOwnerPk,
-      customVerifyingPaymasterAddress: '0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512',
-    };
-  });
+    testCases.forEach(({ field, value, errorMessage }) => {
+      it(`should not set the config with an invalid ${field}`, async () => {
+        const invalidConfig = { ...config, [field]: value };
+        await expect(keyring.setConfig(invalidConfig)).rejects.toThrow(
+          `[Snap] ${errorMessage}: ${value}`,
+        );
+      });
+    });
 
-  const testCases = [
-    ['simpleAccountFactory', '0xNotAnAddress', 'Invalid Simple Account Factory Address'],
-    ['entryPoint', '0xNotAnAddress', 'Invalid Entry Point Address'],
-    ['customVerifyingPaymasterAddress', '0xNotAnAddress', 'Invalid Custom Verifying Paymaster Address'],
-    ['bundlerUrl', 'https:/invalid.fake.io', 'Invalid Bundler URL'],
-    ['customVerifyingPaymasterPK', '123NotAPrivateKey456', 'Invalid Custom Verifying Paymaster Private Key'],
-  ];
-
-  it.each(testCases)('should not set the config with an invalid %s', async (field, value, errorMessage) => {
-    const invalidConfig = { ...config, [field]: value };
-    await expect(keyring.setConfig(invalidConfig)).rejects.toThrow(`[Snap] ${errorMessage}: ${value}`);
-  });
-
-  it('should set the config', async () => {
-    const keyringConfig = await keyring.setConfig(config);
-    expect(keyringConfig).toStrictEqual(config);
-  });
-});
     it('should set the config', async () => {
       const keyringConfig = await keyring.setConfig(config);
       expect(keyringConfig).toStrictEqual(config);


### PR DESCRIPTION
# Description

Minor refactor to the keyring unit tests, particularly the `Set Config` test cases.

Notes,

- The coverage should stay the same for the `keyring.ts` file

| File                 | % Stmts | % Branch | % Funcs | % Lines |
| -------------|---------|----------|---------|--------- |
| `keyring.ts`         |   73.56 |    33.33 |   69.69 |   74.41 |


relates to: https://github.com/MetaMask/accounts-planning/issues/256
reference: PR https://github.com/MetaMask/snap-account-abstraction-keyring/pull/20