### PR TITLE
chore: bump keyring-api to ^8.1.3

### DIFF
--- a/packages/site/package.json
+++ b/packages/site/package.json
@@ -31,7 +31,7 @@
     "@emotion/react": "^11.11.1",
     "@emotion/styled": "^11.11.0",
     "@lavamoat/allow-scripts": "^3.0.4",
-    "@metamask/keyring-api": "^8.0.2",
+    "@metamask/keyring-api": "^8.1.3",
     "@metamask/providers": "^17.1.2",
     "@mui/icons-material": "^5.14.0",
     "@mui/material": "^5.14.0",

--- a/packages/snap/package.json
+++ b/packages/snap/package.json
@@ -45,7 +45,7 @@
   "dependencies": {
     "@ethereumjs/tx": "^5.3.0",
     "@ethereumjs/util": "^9.0.3",
-    "@metamask/keyring-api": "^8.0.2",
+    "@metamask/keyring-api": "^8.1.3",
     "@metamask/snaps-sdk": "^6.1.1",
     "@metamask/superstruct": "^3.0.1",
     "@metamask/utils": "^9.1.0",

--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "git+https://github.com/MetaMask/snap-account-abstraction-keyring.git"
   },
   "source": {
-    "shasum": "WPS+OiPjEbReZSd5SQsBRpYiGdMGCHyhlPPPqATdnPk=",
+    "shasum": "7tU0wyKtdu97f6cLTRKThGLrVUB98ZU0uX/35ulzFRY=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5146,19 +5146,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/keyring-api@npm:^8.0.2":
-  version: 8.0.2
-  resolution: "@metamask/keyring-api@npm:8.0.2"
+"@metamask/keyring-api@npm:^8.1.3":
+  version: 8.1.3
+  resolution: "@metamask/keyring-api@npm:8.1.3"
   dependencies:
-    "@metamask/snaps-sdk": ^6.1.0
+    "@metamask/snaps-sdk": ^6.5.1
     "@metamask/superstruct": ^3.1.0
-    "@metamask/utils": ^9.1.0
+    "@metamask/utils": ^9.2.1
     "@types/uuid": ^9.0.8
     bech32: ^2.0.0
     uuid: ^9.0.1
   peerDependencies:
-    "@metamask/providers": ">=15 <18"
-  checksum: e55ba797cc074a9154d971e3754b63098cb7cd01291216a767dd33ae424e7473075452884c58e037489751a3443575a4bff846b224664184b87e31ad199245ff
+    "@metamask/providers": ^17.2.0
+  checksum: 5943878fa9e47aae1c5ef49a2bcdf7f69fd68532cc9ca8ab1b8d2682cd91c1ac9a6db8219df6365d71b3dcf29731f854699c74f2b3bf68a9d03ebecc5fb71e30
   languageName: node
   linkType: hard
 
@@ -5340,7 +5340,7 @@ __metadata:
     "@metamask/eslint-config-jest": ^12.1.0
     "@metamask/eslint-config-nodejs": ^12.1.0
     "@metamask/eslint-config-typescript": ^12.1.0
-    "@metamask/keyring-api": ^8.0.2
+    "@metamask/keyring-api": ^8.1.3
     "@metamask/providers": ^17.1.2
     "@mui/icons-material": ^5.14.0
     "@mui/material": ^5.14.0
@@ -5393,7 +5393,7 @@ __metadata:
     "@metamask/eslint-config-jest": ^12.1.0
     "@metamask/eslint-config-nodejs": ^12.1.0
     "@metamask/eslint-config-typescript": ^12.1.0
-    "@metamask/keyring-api": ^8.0.2
+    "@metamask/keyring-api": ^8.1.3
     "@metamask/snaps-cli": ^6.2.1
     "@metamask/snaps-sdk": ^6.1.1
     "@metamask/superstruct": ^3.0.1
@@ -5535,6 +5535,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@metamask/snaps-sdk@npm:^6.5.1":
+  version: 6.6.0
+  resolution: "@metamask/snaps-sdk@npm:6.6.0"
+  dependencies:
+    "@metamask/key-tree": ^9.1.2
+    "@metamask/providers": ^17.1.2
+    "@metamask/rpc-errors": ^6.3.1
+    "@metamask/superstruct": ^3.1.0
+    "@metamask/utils": ^9.2.1
+  checksum: 5ed1681b0456cdfbb0fdaf32dd7b5f1e12ed62acaec17d462ed1d4579ac4c2de9543e4c92fed04774c5cf7864a522100d0c3560fb643e13c34f51296087abe65
+  languageName: node
+  linkType: hard
+
 "@metamask/snaps-utils@npm:^7.0.1, @metamask/snaps-utils@npm:^7.7.0":
   version: 7.8.1
   resolution: "@metamask/snaps-utils@npm:7.8.1"
@@ -5629,6 +5642,23 @@ __metadata:
     semver: ^7.5.4
     uuid: ^9.0.1
   checksum: 01f2c71a8f06158d5335bfe96bfd2f3aa39ec6b2323c5d0ff1d3136071a3e8ff7c1804d640ba1d4e07f96f3e68a95ff7729ddfcd34b373e5fefd86d6ef12d034
+  languageName: node
+  linkType: hard
+
+"@metamask/utils@npm:^9.2.1":
+  version: 9.2.1
+  resolution: "@metamask/utils@npm:9.2.1"
+  dependencies:
+    "@ethereumjs/tx": ^4.2.0
+    "@metamask/superstruct": ^3.1.0
+    "@noble/hashes": ^1.3.1
+    "@scure/base": ^1.1.3
+    "@types/debug": ^4.1.7
+    debug: ^4.3.4
+    pony-cause: ^2.1.10
+    semver: ^7.5.4
+    uuid: ^9.0.1
+  checksum: 1a0c842d6fe490bb068c74c6c0684a3e5fabdadcf653b1c83bc69832e9e515fbae5809be20ddfc5c31715cd3d90cf18b73088d9c81f99028ff7b2c7160358c4e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Aligning the keyring-api version to use the new packages from the monorepo.