### PR TITLE
fix: returns `null` if `handleKeyringRequest` returns `undefined`/`void`

### DIFF
--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "git+https://github.com/MetaMask/snap-account-abstraction-keyring.git"
   },
   "source": {
-    "shasum": "dCSUeB+g6G3BuAX2pdWiFkOYaAFdaQUiD7xLWwMW2BA=",
+    "shasum": "95Oe9d2pdj2Df3Jxm0umJH57lkv8C+c97T5NCzyn5DE=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snap/src/index.ts
+++ b/packages/snap/src/index.ts
@@ -87,8 +87,6 @@ export const onRpcRequest: OnRpcRequestHandler = async ({
   }
 };
 
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore TODO: fix types
 export const onKeyringRequest: OnKeyringRequestHandler = async ({
   origin,
   request,
@@ -106,5 +104,5 @@ export const onKeyringRequest: OnKeyringRequestHandler = async ({
   }
 
   // Handle keyring methods.
-  return handleKeyringRequest(await getKeyring(), request);
+  return (await handleKeyringRequest(await getKeyring(), request)) ?? null;
 };


### PR DESCRIPTION
Since `handleKeyringRequest` might returns `void`, this would be evaluated to `undefined` which is not a valid value for the `Json` type. In this case, we returns `null`.