### PR TITLE
chore: make @metamask/snap-account-abstraction-keyring-site publishable

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -35,6 +35,7 @@ jobs:
         with:
           path: |
             ./packages/*/dist
+            ./packages/site/public
             ./node_modules/.yarn-state.yml
           key: ${{ github.sha }}
 
@@ -50,6 +51,7 @@ jobs:
         with:
           path: |
             ./packages/*/dist
+            ./packages/site/public
             ./node_modules/.yarn-state.yml
           key: ${{ github.sha }}
       - name: Dry Run Publish
@@ -74,6 +76,7 @@ jobs:
         with:
           path: |
             ./packages/*/dist
+            ./packages/site/public
             ./node_modules/.yarn-state.yml
           key: ${{ github.sha }}
       - name: Publish

--- a/packages/site/package.json
+++ b/packages/site/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@metamask/snap-account-abstraction-keyring-site",
   "version": "0.5.0",
-  "private": true,
+  "description": "A snap account abstraction keyring dapp used in MetaMask e2e tests.",
   "license": "(MIT-0 OR Apache-2.0)",
   "scripts": {
     "build": "rimraf .cache && cross-env GATSBY_TELEMETRY_DISABLED=1 gatsby build --prefix-paths",
@@ -14,6 +14,12 @@
     "lint:changelog": "auto-changelog validate --prettier",
     "lint:types": "tsc --noEmit",
     "start": "rimraf .cache && cross-env GATSBY_TELEMETRY_DISABLED=1 gatsby develop"
+  },
+  "files": [
+    "public"
+  ],
+  "publishConfig": {
+    "access": "public"
   },
   "browserslist": {
     "production": [

--- a/packages/site/package.json
+++ b/packages/site/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@metamask/snap-account-abstraction-keyring-site",
   "version": "0.5.0",
-  "description": "A snap account abstraction keyring dapp used in MetaMask e2e tests.",
+  "description": "A Snap account abstraction keyring dapp used in MetaMask e2e tests.",
   "license": "(MIT-0 OR Apache-2.0)",
   "scripts": {
     "build": "rimraf .cache && cross-env GATSBY_TELEMETRY_DISABLED=1 gatsby build --prefix-paths",


### PR DESCRIPTION
<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Are there any issues or other links reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->

## Description

Similar to what we did for the snap-simple-keyring-site, we are now doing the same for the account abstraction keyring site: we make the site publishable as an npm package, so we can then use that in our e2e as a local server, instead of going to the live site.

See PRs for context:

- https://github.com/MetaMask/snap-simple-keyring/pull/163
- https://github.com/MetaMask/snap-simple-keyring/pull/166
- https://github.com/MetaMask/snap-simple-keyring/pull/168
- https://github.com/MetaMask/metamask-extension/pull/36557

<!--
Are there any examples of this change being used in another repository?

When considering changes to the MetaMask module template, it's strongly preferred that the change be experimented with in another repository first. This gives reviewers a better sense of how the change works, making it less likely the change will need to be reverted or adjusted later.
-->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Makes the site package publishable on npm and updates CI to cache the built `public` directory.
> 
> - **Package (`packages/site/package.json`)**:
>   - Add `description`, `files: ["public"]`, and `publishConfig.access: "public"`; remove `private` to enable npm publishing.
> - **CI (`.github/workflows/publish-release.yml`)**:
>   - Cache site build output by adding `./packages/site/public` to cache paths in `publish-release`, `publish-npm-dry-run`, and `publish-npm` jobs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 331f5cec134dc6f09eaac4e64ec09b45cdf04598. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->